### PR TITLE
Allow building the server on FreeBSD

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build package run stop run-client run-server run-haserver stop-haserver stop-client stop-server restart restart-server restart-client restart-haserver start-docker update-docker clean-dist clean nuke check-style check-client-style check-server-style check-unit-tests test dist run-client-tests setup-run-client-tests cleanup-run-client-tests test-client build-linux build-osx build-windows package-prep package-linux package-osx package-windows internal-test-web-client vet run-server-for-web-client-tests diff-config prepackaged-plugins prepackaged-binaries test-server test-server-ee test-server-quick test-server-race test-mmctl-unit test-mmctl-e2e test-mmctl test-mmctl-coverage mmctl-build mmctl-docs new-migration migrations-extract test-public mocks-public
+.PHONY: build package run stop run-client run-server run-haserver stop-haserver stop-client stop-server restart restart-server restart-client restart-haserver start-docker update-docker clean-dist clean nuke check-style check-client-style check-server-style check-unit-tests test dist run-client-tests setup-run-client-tests cleanup-run-client-tests test-client build-linux build-osx build-freebsd build-windows package-prep package-linux package-osx package-windows internal-test-web-client vet run-server-for-web-client-tests diff-config prepackaged-plugins prepackaged-binaries test-server test-server-ee test-server-quick test-server-race test-mmctl-unit test-mmctl-e2e test-mmctl test-mmctl-coverage mmctl-build mmctl-docs new-migration migrations-extract test-public mocks-public
 
 ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
@@ -125,6 +125,8 @@ DIST_PATH_LIN_AMD64=$(DIST_ROOT)/linux_amd64/mattermost
 DIST_PATH_LIN_ARM64=$(DIST_ROOT)/linux_arm64/mattermost
 DIST_PATH_OSX_AMD64=$(DIST_ROOT)/osx_amd64/mattermost
 DIST_PATH_OSX_ARM64=$(DIST_ROOT)/osx_arm64/mattermost
+DIST_PATH_FREEBSD_AMD64=$(DIST_ROOT)/freebsd_amd64/mattermost
+DIST_PATH_FREEBSD_ARM64=$(DIST_ROOT)/freebsd_arm64/mattermost
 DIST_PATH_WIN=$(DIST_ROOT)/windows/mattermost
 
 # Packages lists

--- a/server/build/release.mk
+++ b/server/build/release.mk
@@ -36,6 +36,26 @@ else
 	env GOOS=darwin GOARCH=arm64 $(GO) build -o $(GOBIN)/darwin_arm64 $(GOFLAGS) -trimpath -tags production -ldflags '$(LDFLAGS)' ./...
 endif
 
+build-freebsd: build-freebsd-amd64 build-freebsd-arm64
+
+build-freebsd-amd64:
+	@echo Build FreeBSD amd64
+ifeq ($(BUILDER_GOOS_GOARCH),"freebsd_amd64")
+	env GOOS=freebsd GOARCH=amd64 $(GO) build -o $(GOBIN) $(GOFLAGS) -trimpath -tags production -ldflags '$(LDFLAGS)' ./...
+else
+	mkdir -p $(GOBIN)/freebsd_amd64
+	env GOOS=freebsd GOARCH=amd64 $(GO) build -o $(GOBIN)/freebsd_amd64 $(GOFLAGS) -trimpath -tags production -ldflags '$(LDFLAGS)' ./...
+endif
+
+build-freebsd-arm64:
+	@echo Build FreeBSD arm64
+ifeq ($(BUILDER_GOOS_GOARCH),"freebsd_arm64")
+	env GOOS=freebsd GOARCH=arm64 $(GO) build -o $(GOBIN) $(GOFLAGS) -trimpath -tags production -ldflags '$(LDFLAGS)' ./...
+else
+	mkdir -p $(GOBIN)/freebsd_arm64
+	env GOOS=freebsd GOARCH=arm64 $(GO) build -o $(GOBIN)/freebsd_arm64 $(GOFLAGS) -trimpath -tags production -ldflags '$(LDFLAGS)' ./...
+endif
+
 build-windows:
 	@echo Build Windows amd64
 ifeq ($(BUILDER_GOOS_GOARCH),"windows_amd64")
@@ -77,6 +97,22 @@ else
 	env GOOS=darwin GOARCH=arm64 $(GO) build -o $(GOBIN)/darwin_arm64 $(GOFLAGS) -trimpath -tags production -ldflags '$(LDFLAGS)' ./cmd/...
 endif
 
+build-cmd-freebsd:
+	@echo Build CMD FreeBSD amd64
+ifeq ($(BUILDER_GOOS_GOARCH),"freebsd_amd64")
+	env GOOS=freebsd GOARCH=amd64 $(GO) build -o $(GOBIN) $(GOFLAGS) -trimpath -tags production -ldflags '$(LDFLAGS)' ./cmd/...
+else
+	mkdir -p $(GOBIN)/freebsd_amd64
+	env GOOS=freebsd GOARCH=amd64 $(GO) build -o $(GOBIN)/freebsd_amd64 $(GOFLAGS) -trimpath -tags production -ldflags '$(LDFLAGS)' ./cmd/...
+endif
+	@echo Build CMD FreeBSD arm64
+ifeq ($(BUILDER_GOOS_GOARCH),"freebsd_arm64")
+	env GOOS=freebsd GOARCH=arm64 $(GO) build -o $(GOBIN) $(GOFLAGS) -trimpath -tags production -ldflags '$(LDFLAGS)' ./cmd/...
+else
+	mkdir -p $(GOBIN)/freebsd_arm64
+	env GOOS=freebsd GOARCH=arm64 $(GO) build -o $(GOBIN)/freebsd_arm64 $(GOFLAGS) -trimpath -tags production -ldflags '$(LDFLAGS)' ./cmd/...
+endif
+
 build-cmd-windows:
 	@echo Build CMD Windows amd64
 ifeq ($(BUILDER_GOOS_GOARCH),"windows_amd64")
@@ -86,9 +122,9 @@ else
 	env GOOS=windows GOARCH=amd64 $(GO) build -o $(GOBIN)/windows_amd64 $(GOFLAGS) -trimpath -tags production -ldflags '$(LDFLAGS)' ./cmd/...
 endif
 
-build: setup-go-work build-client build-linux build-windows build-osx
+build: setup-go-work build-client build-linux build-windows build-osx build-freebsd
 
-build-cmd: setup-go-work build-client build-cmd-linux build-cmd-windows build-cmd-osx
+build-cmd: setup-go-work build-client build-cmd-linux build-cmd-windows build-cmd-osx build-cmd-freebsd
 
 build-client:
 	@echo Building mattermost web app
@@ -167,6 +203,10 @@ ifeq ("darwin_arm64","$(CURRENT_PACKAGE_ARCH)")
 	echo "No plugins yet for $(CURRENT_PACKAGE_ARCH) platform, skipping..."
 else ifeq ("linux_arm64","$(CURRENT_PACKAGE_ARCH)")
 	echo "No plugins yet for $(CURRENT_PACKAGE_ARCH) platform, skipping..."
+else ifeq ("freebsd_amd64","$(CURRENT_PACKAGE_ARCH)")
+	echo "No plugins yet for $(CURRENT_PACKAGE_ARCH) platform, skipping..."
+else ifeq ("freebsd_arm64","$(CURRENT_PACKAGE_ARCH)")
+	echo "No plugins yet for $(CURRENT_PACKAGE_ARCH) platform, skipping..."
 else
 	@# Prepackage plugins
 	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
@@ -206,6 +246,22 @@ package-osx-arm64: package-prep
 	rm -rf $(DIST_ROOT)/osx_arm64
 
 package-osx: package-osx-amd64 package-osx-arm64
+
+package-freebsd-amd64: package-prep
+	DIST_PATH_GENERIC=$(DIST_PATH_FREEBSD_AMD64) CURRENT_PACKAGE_ARCH=freebsd_amd64 PLUGIN_ARCH=freebsd-amd64 MMCTL_PLATFORM="FreeBSD-x86_64" MM_BIN_NAME=mattermost MMCTL_BIN_NAME=mmctl $(MAKE) package-general
+	@# Package
+	tar -C $(DIST_PATH_FREEBSD_AMD64)/.. -czf $(DIST_PATH)-$(BUILD_TYPE_NAME)-freebsd-amd64.tar.gz mattermost ../mattermost
+	@# Cleanup
+	rm -rf $(DIST_ROOT)/freebsd_amd64
+
+package-freebsd-arm64: package-prep
+	DIST_PATH_GENERIC=$(DIST_PATH_FREEBSD_ARM64) CURRENT_PACKAGE_ARCH=freebsd_arm64 PLUGIN_ARCH=freebsd-arm64 MMCTL_PLATFORM="FreeBSD-arm64" MM_BIN_NAME=mattermost MMCTL_BIN_NAME=mmctl $(MAKE) package-general
+	@# Package
+	tar -C $(DIST_PATH_FREEBSD_ARM64)/.. -czf $(DIST_PATH)-$(BUILD_TYPE_NAME)-freebsd-arm64.tar.gz mattermost ../mattermost
+	@# Cleanup
+	rm -rf $(DIST_ROOT)/freebsd_arm64
+
+package-freebsd: package-freebsd-amd64 package-freebsd-arm64
 
 package-linux-amd64: package-prep
 	DIST_PATH_GENERIC=$(DIST_PATH_LIN_AMD64) CURRENT_PACKAGE_ARCH=linux_amd64 PLUGIN_ARCH=linux-amd64 MMCTL_PLATFORM="Linux-x86_64" MM_BIN_NAME=mattermost MMCTL_BIN_NAME=mmctl $(MAKE) package-general
@@ -259,6 +315,6 @@ endif
 	@# Cleanup
 	rm -rf $(DIST_ROOT)/windows
 
-package: package-osx package-linux package-windows
+package: package-osx package-linux package-freebsd package-windows
 	rm -rf tmpprepackaged
 	rm -rf $(DIST_PATH)

--- a/server/cmd/mmctl/commands/utils_unix.go
+++ b/server/cmd/mmctl/commands/utils_unix.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-//go:build linux || darwin
+//go:build linux || darwin || freebsd
 // +build linux darwin
 
 package commands


### PR DESCRIPTION
#### Summary
Mattermost runs perfectly fine on FreeBSD. It's been in the [FreeBSD ports](https://www.freshports.org/www/mattermost-server) for almost 6 years now.

This PR configures the build process to allow building on FreeBSD along the other operating systems, so that the FreeBSD port maintainer don't need to add funky hacks to their Makefile to basically do the same thing.

#### Ticket Link
No ticket so far. I asked [here](https://community.mattermost.com/core/pl/5c8tm39bwpf5dyf3jsj7f6ttty) and people suggested  I opened the PR anyway. So here we are 😀

#### Screenshots
No functional or UI change => no screenshot.

#### Release Note
```
Configured the build system to natively build the server on FreeBSD.
```
